### PR TITLE
Fix import for go/types

### DIFF
--- a/api.go
+++ b/api.go
@@ -10,9 +10,9 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"go/types"
 
 	"golang.org/x/tools/go/ast/astutil"
-	"golang.org/x/tools/go/types"
 
 	"github.com/motemen/go-astmanip"
 )

--- a/api_test.go
+++ b/api_test.go
@@ -8,8 +8,9 @@ import (
 	"go/ast"
 	"go/printer"
 
+	_ "go/types"
+
 	"golang.org/x/tools/go/loader"
-	_ "golang.org/x/tools/go/types"
 )
 
 func TestRewriteFile(t *testing.T) {


### PR DESCRIPTION
Thanks for a great tool!

Go 1.6 has been merged go/types to Go language core package.
I was fixed `import` for `api.go` and `api_test.go`.
